### PR TITLE
Fix for issue #21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,10 @@
+version: 2
 jobs:
   validate:
     environment:
         AWS_DEFAULT_REGION: us-east-1
     docker:
-      - image: hashicorp/terraform:0.12.6
+      - image: hashicorp/terraform:0.12.16
     steps:
       - checkout
       - run:
@@ -23,7 +24,7 @@ jobs:
           command: curl -L -o /tmp/tflint.zip https://github.com/wata727/tflint/releases/download/v0.9.2/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
       - run:
           name: Check Terraform configurations with tflint
-          command: tflint
+          command: find . -name ".terraform" -prune -o -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m; do (cd "$m" && tflint && echo "√ $m") || exit 1 ; done
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 The code provided within this subcomponent will create the AWS resources necessary to configure and enable logging and log storage. The subcomponent also provides a method for configuring a trust relationship with SecOps to allow for the retrieval and analysis of your AWS CloudTrail log data using their Enterprise Logging Platform. The GRACE Logging subcomponent activates AWS CloudTrail and creates a multi-region CloudTrail Trail configured to deliver to both an Amazon S3 bucket and an Amazon CloudWatch Log Group. The required AWS IAM resources are created to allow for the permissions required for CloudTrail's log delivery. The S3 bucket created for log storage is setup with a bucket policy, lifecycle policy, server-side encryption, versioning, and access logging. The GRACE Logging subcomponent also creates a S3 bucket to store the access-log data generated from the CloudTrail log storage bucket.
 
 The GRACE Logging subcomponent will also provide the resources required to create a trust relationship with SecOps. This trust relationship will allow SecOps to pull the CloudTrail log data from the log storage bucket and analyze it using their Enterprise Logging Platform. The integration with SecOps utilizes AWS Security Token Service (STS) to allow the specified SecOps accounts access to assume a role specifically created for the consumption of the log data stored within the S3 log storage bucket.
->NOTE: Customers can coordinate with [SecOps@gsa.gov](mailto:secops@gsa.gov) to determine the appropriate [AWS Account number(s)](https://github.com/GSA/grace-logging/blob/grace-logging-documentation/variables.tf#L124) to configure for the trust policy. The account numbers specify which trusted account members are allowed to assume the role used for log integration with SecOps. 
+>NOTE: Customers can coordinate with [SecOps@gsa.gov](mailto:secops@gsa.gov) to determine the appropriate [AWS Account number(s)](https://github.com/GSA/grace-logging/blob/grace-logging-documentation/variables.tf#L124) to configure for the trust policy. The account numbers specify which trusted account members are allowed to assume the role used for log integration with SecOps.
 
 ## <a name="contents">Table of Contents</a>
 
@@ -83,8 +83,8 @@ The GRACE Logging subcomponent will also provide the resources required to creat
 ## <a name="guide">Deployment Guide</a>
 
 * Dependencies
-    - Terraform (minimum version v0.10.4; recommend v0.12.6 or greater)
-        - provider.aws ~v2.24.0
+    - Terraform (minimum version v0.12.x; recommend v0.12.6 or greater)
+        - provider.aws ~v2.38.0
         - provider.template ~v2.1.2
 
 * Usage
@@ -110,7 +110,7 @@ The GRACE Logging subcomponent provides various levels of coverage for several [
 
 **Subcomponent approval status:** `Pending Assessment`
 
-**Relevant controls:** 
+**Relevant controls:**
 
 | Control Description | Control ID |
 |-|:-:|

--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -6,28 +6,28 @@
 
 # Setup CloudTrail
 resource "aws_cloudtrail" "cloudtrail" {
-  name                          = "${var.cloudtrail_name}"
-  s3_bucket_name                = "${aws_s3_bucket.logging.bucket}"
-  s3_key_prefix                 = "${var.cloudtrail_bucket_prefix}"
-  include_global_service_events = "${var.cloudtrail_include_global_service_events}"
-  is_multi_region_trail         = "${var.cloudtrail_multi_region}"
-  enable_log_file_validation    = "${var.cloudtrail_enable_log_validation}"
-  kms_key_id                    = "${aws_kms_key.cloudtrail.arn}"
-  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail.arn}"
-  cloud_watch_logs_role_arn     = "${aws_iam_role.cloudtrail.arn}"
+  name                          = var.cloudtrail_name
+  s3_bucket_name                = aws_s3_bucket.logging.bucket
+  s3_key_prefix                 = var.cloudtrail_bucket_prefix
+  include_global_service_events = var.cloudtrail_include_global_service_events
+  is_multi_region_trail         = var.cloudtrail_multi_region
+  enable_log_file_validation    = var.cloudtrail_enable_log_validation
+  kms_key_id                    = aws_kms_key.cloudtrail.arn
+  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
+  cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
 
-  depends_on = ["aws_s3_bucket_policy.logging"]
+  depends_on = [aws_s3_bucket_policy.logging]
 }
 
 # Create Log Group
 resource "aws_cloudwatch_log_group" "cloudtrail" {
-  name              = "${var.cloudtrail_name}"
-  retention_in_days = "${var.cloudtrail_log_retention_days}"
+  name              = var.cloudtrail_name
+  retention_in_days = var.cloudtrail_log_retention_days
 }
 
 # Create IAM Role
 resource "aws_iam_role" "cloudtrail" {
-  name = "${var.cloudtrail_name}"
+  name = var.cloudtrail_name
 
   assume_role_policy = <<END_OF_POLICY
 {
@@ -44,12 +44,14 @@ resource "aws_iam_role" "cloudtrail" {
   ]
 }
 END_OF_POLICY
+
 }
+
 # Create IAM Policy for Role
 resource "aws_iam_role_policy" "cloudtrail" {
-  name = "${var.cloudtrail_name}"
+  name = var.cloudtrail_name
 
-  role = "${aws_iam_role.cloudtrail.id}"
+  role = aws_iam_role.cloudtrail.id
 
   policy = <<END_OF_POLICY
 {
@@ -78,13 +80,14 @@ resource "aws_iam_role_policy" "cloudtrail" {
   ]
 }
 END_OF_POLICY
+
 }
 
 data "template_file" "cloudtrail_key_policy" {
-  template = "${file("${path.module}/files/cloudtrail_key_policy.tpl.json")}"
+  template = file("${path.module}/files/cloudtrail_key_policy.tpl.json")
   vars = {
-    account_id = "${data.aws_caller_identity.current.account_id}"
-    region     = "${data.aws_region.current.name}"
+    account_id = data.aws_caller_identity.current.account_id
+    region     = data.aws_region.current.name
   }
 }
 
@@ -93,5 +96,6 @@ resource "aws_kms_key" "cloudtrail" {
   description         = "A KMS key to encrypt CloudTrail events."
   enable_key_rotation = "true"
 
-  policy = "${data.template_file.cloudtrail_key_policy.rendered}"
+  policy = data.template_file.cloudtrail_key_policy.rendered
 }
+

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -6,66 +6,66 @@
 
 # Create Bucket
 resource "aws_s3_bucket" "logging" {
-  bucket = "${var.logging_bucket_name}"
-  acl    = "${var.logging_bucket_acl}"
+  bucket = var.logging_bucket_name
+  acl    = var.logging_bucket_acl
 
   logging {
-    target_bucket = "${aws_s3_bucket.access.id}"
-    target_prefix = "${var.logging_access_logging_prefix}"
+    target_bucket = aws_s3_bucket.access.id
+    target_prefix = var.logging_access_logging_prefix
   }
 
   versioning {
-    enabled = "${var.logging_bucket_enable_versioning}"
+    enabled = var.logging_bucket_enable_versioning
   }
 
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = "${aws_kms_key.cloudtrail.arn}"
+        kms_master_key_id = aws_kms_key.cloudtrail.arn
         sse_algorithm     = "aws:kms"
       }
     }
   }
 
   lifecycle_rule {
-    enabled = "${var.logging_bucket_enable_backup}"
+    enabled = var.logging_bucket_enable_backup
 
-    prefix = "${var.logging_access_logging_prefix}"
+    prefix = var.logging_access_logging_prefix
 
     transition {
-      days          = "${var.logging_bucket_backup_days}"
+      days          = var.logging_bucket_backup_days
       storage_class = "GLACIER"
     }
 
     expiration {
-      days = "${var.logging_bucket_backup_expiration_days}"
+      days = var.logging_bucket_backup_expiration_days
     }
   }
 }
 
 # Set Public Access Block
 resource "aws_s3_bucket_public_access_block" "logging" {
-  bucket = "${aws_s3_bucket.logging.id}"
+  bucket = aws_s3_bucket.logging.id
 
-  block_public_acls       = "${var.logging_bucket_block_public_acls}"
-  ignore_public_acls      = "${var.logging_bucket_ignore_public_acls}"
-  block_public_policy     = "${var.logging_bucket_block_public_policy}"
-  restrict_public_buckets = "${var.logging_bucket_restrict_public_buckets}"
+  block_public_acls       = var.logging_bucket_block_public_acls
+  ignore_public_acls      = var.logging_bucket_ignore_public_acls
+  block_public_policy     = var.logging_bucket_block_public_policy
+  restrict_public_buckets = var.logging_bucket_restrict_public_buckets
 }
 
 data "template_file" "bucket_policy" {
-  template = "${file("${path.module}/files/bucket_policy.tpl.json")}"
+  template = file("${path.module}/files/bucket_policy.tpl.json")
   vars = {
-    bucket            = "${var.logging_bucket_name}"
-    flowlog_folder    = "${var.flowlogs_bucket_prefix}"
-    cloudtrail_folder = "${var.cloudtrail_bucket_prefix}"
+    bucket            = var.logging_bucket_name
+    flowlog_folder    = var.flowlogs_bucket_prefix
+    cloudtrail_folder = var.cloudtrail_bucket_prefix
   }
 }
 
 # Create Bucket Policy
 resource "aws_s3_bucket_policy" "logging" {
-  bucket = "${aws_s3_bucket.logging.id}"
-  policy = "${data.template_file.bucket_policy.rendered}"
+  bucket = aws_s3_bucket.logging.id
+  policy = data.template_file.bucket_policy.rendered
 }
 
 ######################################
@@ -76,25 +76,25 @@ resource "aws_s3_bucket_policy" "logging" {
 
 # Create S3 Bucket
 resource "aws_s3_bucket" "access" {
-  bucket = "${var.access_logging_bucket_name}"
-  acl    = "${var.access_logging_bucket_acl}"
+  bucket = var.access_logging_bucket_name
+  acl    = var.access_logging_bucket_acl
 
   versioning {
-    enabled = "${var.access_logging_bucket_enable_versioning}"
+    enabled = var.access_logging_bucket_enable_versioning
   }
 
   lifecycle_rule {
-    enabled = "${var.access_logging_bucket_enable_backup}"
+    enabled = var.access_logging_bucket_enable_backup
 
-    prefix = "${var.access_logging_bucket_name}"
+    prefix = var.access_logging_bucket_name
 
     transition {
-      days          = "${var.access_logging_bucket_backup_days}"
+      days          = var.access_logging_bucket_backup_days
       storage_class = "GLACIER"
     }
 
     expiration {
-      days = "${var.access_logging_bucket_backup_expiration_days}"
+      days = var.access_logging_bucket_backup_expiration_days
     }
   }
 
@@ -109,10 +109,11 @@ resource "aws_s3_bucket" "access" {
 
 # Set Public Access Block
 resource "aws_s3_bucket_public_access_block" "access" {
-  bucket = "${aws_s3_bucket.access.id}"
+  bucket = aws_s3_bucket.access.id
 
-  block_public_acls       = "${var.access_logging_bucket_block_public_acls}"
-  ignore_public_acls      = "${var.access_logging_bucket_ignore_public_acls}"
-  block_public_policy     = "${var.access_logging_bucket_block_public_policy}"
-  restrict_public_buckets = "${var.access_logging_bucket_restrict_public_buckets}"
+  block_public_acls       = var.access_logging_bucket_block_public_acls
+  ignore_public_acls      = var.access_logging_bucket_ignore_public_acls
+  block_public_policy     = var.access_logging_bucket_block_public_policy
+  restrict_public_buckets = var.access_logging_bucket_restrict_public_buckets
 }
+

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,11 @@
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
+data "aws_caller_identity" "current" {
+}
+
+data "aws_region" "current" {
+}
 
 locals {
-  account_id = "${data.aws_caller_identity.current.account_id}"
-  region     = "${data.aws_region.current.name}"
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.name
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,60 +1,61 @@
 output "cloudtrail_id" {
   description = "The name of the trail."
-  value       = "${aws_cloudtrail.cloudtrail.id}"
+  value       = aws_cloudtrail.cloudtrail.id
 }
 
 output "cloudtrail_arn" {
   description = "The Amazon Resource Name of the trail."
-  value       = "${aws_cloudtrail.cloudtrail.arn}"
+  value       = aws_cloudtrail.cloudtrail.arn
 }
 
 output "cloudtrail_log_group_arn" {
   description = "The Amazon Resource Name (ARN) specifying the CloudTrail log group"
-  value       = "${aws_cloudwatch_log_group.cloudtrail.arn}"
+  value       = aws_cloudwatch_log_group.cloudtrail.arn
 }
 
 output "cloudtrail_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the CloudTrail role."
-  value       = "${aws_iam_role.cloudtrail.arn}"
+  value       = aws_iam_role.cloudtrail.arn
 }
 
 output "cloudtrail_role_id" {
   description = "The name of the CloudTrail role."
-  value       = "${aws_iam_role.cloudtrail.id}"
+  value       = aws_iam_role.cloudtrail.id
 }
 
 output "cloudtrail_policy_id" {
   description = "The ID of the CloudTrail policy."
-  value       = "${aws_iam_role_policy.cloudtrail.id}"
+  value       = aws_iam_role_policy.cloudtrail.id
 }
 
 output "cloudtrail_kms_key_arn" {
   description = "The Amazon Resource Name (ARN) of the CloudTrail KMS key."
-  value       = "${aws_kms_key.cloudtrail.arn}"
+  value       = aws_kms_key.cloudtrail.arn
 }
 
 output "cloudtrail_kms_key_id" {
   description = "The globally unique identifier for the CloudTrail KMS key."
-  value       = "${aws_kms_key.cloudtrail.key_id}"
+  value       = aws_kms_key.cloudtrail.key_id
 }
 
 output "logging_bucket_arn" {
   description = "The ARN of the logging bucket."
-  value       = "${aws_s3_bucket.logging.arn}"
+  value       = aws_s3_bucket.logging.arn
 }
 
 output "logging_bucket_id" {
   description = "The name of the logging bucket."
-  value       = "${aws_s3_bucket.logging.id}"
+  value       = aws_s3_bucket.logging.id
 }
 
 output "access_bucket_id" {
   description = "The name of the access log bucket."
-  value       = "${aws_s3_bucket.access.id}"
+  value       = aws_s3_bucket.access.id
 }
+
 output "access_bucket_arn" {
   description = "The ARN of the access log bucket."
-  value       = "${aws_s3_bucket.access.arn}"
+  value       = aws_s3_bucket.access.arn
 }
 
 output "secops_role_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,15 +59,24 @@ output "access_bucket_arn" {
 
 output "secops_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the secops read only role."
-  value       = "${aws_iam_role.secops.0.arn}"
+  value = [
+    for index in aws_iam_role.secops :
+    aws_iam_role.secops[index]["arn"]
+  ]
 }
 
 output "secops_role_id" {
   description = "The name of the secops read only role."
-  value       = "${aws_iam_role.secops.0.id}"
+  value = [
+    for index in aws_iam_role.secops :
+    aws_iam_role.secops[index]["id"]
+  ]
 }
 
 output "secops_policy_id" {
   description = "The ID of the secops read only policy."
-  value       = "${aws_iam_role_policy.secops.0.id}"
+  value = [
+    for index in aws_iam_role_policy.secops :
+    aws_iam_role_policy.secops[index]["id"]
+  ]
 }

--- a/secops.tf
+++ b/secops.tf
@@ -6,28 +6,28 @@
 
 # Generate assume_role_policy from secops_accounts variable
 data "aws_iam_policy_document" "secops" {
-  count = "${length(var.secops_accounts) > 0 ? 1 : 0}"
+  count = length(var.secops_accounts) > 0 ? 1 : 0
   statement {
     actions = ["sts:AssumeRole"]
     principals {
       type        = "AWS"
-      identifiers = "${formatlist("arn:aws:iam::%s:root", split(",", "${var.secops_accounts}"))}"
+      identifiers = formatlist("arn:aws:iam::%s:root", split(",", var.secops_accounts))
     }
   }
 }
 
 # Create IAM Role with assume_role_policy
 resource "aws_iam_role" "secops" {
-  count              = "${length(var.secops_accounts) > 0 ? 1 : 0}"
-  name               = "${var.secops_role_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.secops.0.json}"
+  count              = length(var.secops_accounts) > 0 ? 1 : 0
+  name               = var.secops_role_name
+  assume_role_policy = data.aws_iam_policy_document.secops[0].json
 }
 
 # Create IAM policy
 resource "aws_iam_role_policy" "secops" {
-  count = "${length(var.secops_accounts) > 0 ? 1 : 0}"
-  name  = "${var.secops_role_name}"
-  role  = "${aws_iam_role.secops.0.id}"
+  count = length(var.secops_accounts) > 0 ? 1 : 0
+  name  = var.secops_role_name
+  role  = aws_iam_role.secops[0].id
 
   policy = <<EOF
 {
@@ -52,4 +52,6 @@ resource "aws_iam_role_policy" "secops" {
     ]
 }
 EOF
+
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,5 @@
-
 variable "access_logging_bucket_name" {
-  type        = "string"
+  type        = string
   description = "(required) The name given to the access logging bucket"
 }
 
@@ -8,14 +7,17 @@ variable "access_logging_bucket_acl" {
   description = "(optional) The ACL applied to the access logging bucket"
   default     = "log-delivery-write"
 }
+
 variable "access_logging_bucket_enable_versioning" {
   description = "(optional) The boolean value enabling (true) or disabling (false) versioning on the access logging bucket"
   default     = "true"
 }
+
 variable "access_logging_bucket_enable_backup" {
   description = "(optional) The boolean value enabling (true) or disabling (false) backups to glacier on the access logging bucket"
   default     = "true"
 }
+
 variable "access_logging_bucket_backup_days" {
   description = "(optional) The age of an object in number of days before it can be archived to glacier"
   default     = "365"
@@ -30,14 +32,17 @@ variable "access_logging_bucket_block_public_acls" {
   description = "(optional) The boolean value enabling (true) or disabling (false) the blocking of public ACL creation for the access logging bucket"
   default     = "true"
 }
+
 variable "access_logging_bucket_ignore_public_acls" {
   description = "(optional) The boolean value enabling (true) or disabling (false) the ignoring of public ACLs created for the access logging bucket"
   default     = "true"
 }
+
 variable "access_logging_bucket_block_public_policy" {
   description = "(optional) The boolean value enabling (true) or disabling (false) the blocking of public policy creation for the access logging bucket"
   default     = "true"
 }
+
 variable "access_logging_bucket_restrict_public_buckets" {
   description = "(optional) The boolean value enabling (true) or disabling (false) the blocking of public and cross-account access with the public bucket policy for the access logging bucket"
   default     = "true"
@@ -47,6 +52,7 @@ variable "cloudtrail_name" {
   description = "(optional) The name given to the CloudTrail"
   default     = "grace-cloudtrail"
 }
+
 variable "cloudtrail_bucket_prefix" {
   description = "(optional) The prefix used when storing CloudTrail logs in the logging bucket"
   default     = "grace-cloudtrail"
@@ -61,39 +67,47 @@ variable "cloudtrail_include_global_service_events" {
   description = "(optional) The boolean value indicating whether global services are sending events to this CloudTrail (ie: IAM)"
   default     = "true"
 }
+
 variable "cloudtrail_multi_region" {
   description = "(optional) The boolean value indicating whether this CloudTrail is multi-region"
   default     = "true"
 }
+
 variable "cloudtrail_enable_log_validation" {
   description = "(optional) The boolean value indicating whether this CloudTrail should perform log file integrity validation"
   default     = "true"
 }
+
 variable "cloudtrail_log_retention_days" {
   description = "(optional) The number of days to retain logs in the CloudWatch log group"
   default     = "365"
 }
 
 variable "logging_bucket_name" {
-  type        = "string"
+  type        = string
   description = "(required) The name given to the primary logging bucket"
 }
+
 variable "logging_access_logging_prefix" {
   description = "(optional) The prefix used when storing access logs for the logging bucket"
   default     = "grace-logging"
 }
+
 variable "logging_bucket_acl" {
   description = "(optional) The ACL applied to the primary logging bucket"
   default     = "log-delivery-write"
 }
+
 variable "logging_bucket_enable_versioning" {
   description = "(optional) The boolean value enabling (true) or disabling (false) versioning on the logging bucket"
   default     = "true"
 }
+
 variable "logging_bucket_enable_backup" {
   description = "(optional) The boolean value enabling (true) or disabling (false) backups to glacier on the logging bucket"
   default     = "true"
 }
+
 variable "logging_bucket_backup_days" {
   description = "(optional) The age of an object in number of days before it can be archived to glacier"
   default     = "365"
@@ -108,14 +122,17 @@ variable "logging_bucket_block_public_acls" {
   description = "(optional) The boolean value enabling (true) or disabling (false) the blocking of public ACL creation for the logging bucket"
   default     = "true"
 }
+
 variable "logging_bucket_ignore_public_acls" {
   description = "(optional) The boolean value enabling (true) or disabling (false) the ignoring of public ACLs created for the logging bucket"
   default     = "true"
 }
+
 variable "logging_bucket_block_public_policy" {
   description = "(optional) The boolean value enabling (true) or disabling (false) the blocking of public policy creation for the logging bucket"
   default     = "true"
 }
+
 variable "logging_bucket_restrict_public_buckets" {
   description = "(optional) The boolean value enabling (true) or disabling (false) the blocking of public and cross-account access with the public bucket policy for the logging bucket"
   default     = "true"
@@ -125,7 +142,9 @@ variable "secops_accounts" {
   description = "(optional) A comma delimited string containing the Account IDs of accounts that should access to your log buckets, if empty no external accounts will be allowed to read the logs"
   default     = ""
 }
+
 variable "secops_role_name" {
   description = "(optional) The name given to the SecOps read only access to the logging bucket"
   default     = "grace-secops-read"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
- bumps terraform version to v0.12.16
- uses for loops for secops role and policy outputs (Closes #21 )
- Fixes command to run `tflint` on all terraform files
- Requires Terraform v0.12+
- Updated syntax with `terraform 0.12upgrade`