### PR TITLE
Feature - Force Destroy for S3 Buckets

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -6,8 +6,9 @@
 
 # Create Bucket
 resource "aws_s3_bucket" "logging" {
-  bucket = var.logging_bucket_name
-  acl    = var.logging_bucket_acl
+  bucket        = var.logging_bucket_name
+  acl           = var.logging_bucket_acl
+  force_destroy = var.logging_bucket_destroy
 
   logging {
     target_bucket = aws_s3_bucket.access.id
@@ -76,8 +77,9 @@ resource "aws_s3_bucket_policy" "logging" {
 
 # Create S3 Bucket
 resource "aws_s3_bucket" "access" {
-  bucket = var.access_logging_bucket_name
-  acl    = var.access_logging_bucket_acl
+  bucket        = var.access_logging_bucket_name
+  acl           = var.access_logging_bucket_acl
+  force_destroy = var.access_logging_bucket_destroy
 
   versioning {
     enabled = var.access_logging_bucket_enable_versioning

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "access_logging_bucket_name" {
   description = "(required) The name given to the access logging bucket"
 }
 
+variable "access_logging_bucket_destroy" {
+  type        = boolean
+  description = "(optional) The boolean value indicating whether Terraform can destroy the bucket with objects still inside"
+  optional    = "false"
+}
+
 variable "access_logging_bucket_acl" {
   description = "(optional) The ACL applied to the access logging bucket"
   default     = "log-delivery-write"
@@ -86,6 +92,12 @@ variable "cloudtrail_log_retention_days" {
 variable "logging_bucket_name" {
   type        = string
   description = "(required) The name given to the primary logging bucket"
+}
+
+variable "logging_bucket_destroy" {
+  type        = boolean
+  description = "(optional) The boolean value indicating whether Terraform can destroy the bucket with objects still inside"
+  optional    = "false"
 }
 
 variable "logging_access_logging_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,6 @@ variable "access_logging_bucket_name" {
 }
 
 variable "access_logging_bucket_destroy" {
-  type        = boolean
   description = "(optional) The boolean value indicating whether Terraform can destroy the bucket with objects still inside"
   default    = "false"
 }
@@ -95,7 +94,6 @@ variable "logging_bucket_name" {
 }
 
 variable "logging_bucket_destroy" {
-  type        = boolean
   description = "(optional) The boolean value indicating whether Terraform can destroy the bucket with objects still inside"
   default    = "false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "access_logging_bucket_name" {
 variable "access_logging_bucket_destroy" {
   type        = boolean
   description = "(optional) The boolean value indicating whether Terraform can destroy the bucket with objects still inside"
-  optional    = "false"
+  default    = "false"
 }
 
 variable "access_logging_bucket_acl" {
@@ -97,7 +97,7 @@ variable "logging_bucket_name" {
 variable "logging_bucket_destroy" {
   type        = boolean
   description = "(optional) The boolean value indicating whether Terraform can destroy the bucket with objects still inside"
-  optional    = "false"
+  default    = "false"
 }
 
 variable "logging_access_logging_prefix" {


### PR DESCRIPTION
Added the force_destroy option to the two S3 Buckets created from this logging repo.  The issue we were encountering was terraform destroys are not graceful without it. You would manually need to delete bucket contents and versions.