### PR TITLE
Add cloudwatch log group name to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The GRACE Logging subcomponent will also provide the resources required to creat
 | cloudtrail\_kms\_key\_arn | The Amazon Resource Name \(ARN\) of the CloudTrail KMS key. |
 | cloudtrail\_kms\_key\_id | The globally unique identifier for the CloudTrail KMS key. |
 | cloudtrail\_log\_group\_arn | The Amazon Resource Name \(ARN\) specifying the CloudTrail log group |
+| cloudtrail\_log\_group\_name | The name of the CloudTrail log group |
 | cloudtrail\_policy\_id | The ID of the CloudTrail policy. |
 | cloudtrail\_role\_arn | The Amazon Resource Name \(ARN\) specifying the CloudTrail role. |
 | cloudtrail\_role\_id | The name of the CloudTrail role. |
@@ -94,7 +95,7 @@ Include the module in your Terraform project.  See the above [inputs](#inputs) a
 
 ```
 module "logging" {
-  source                     = "github.com/GSA/grace-logging?ref=v0.0.3"
+  source                     = "github.com/GSA/grace-logging?ref=v0.0.5"
   access_logging_bucket_name = "example-access-logs"
   cloudtrail_name            = "example-trail"
   logging_bucket_name        = "example-logs"

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "cloudtrail_log_group_arn" {
   value       = aws_cloudwatch_log_group.cloudtrail.arn
 }
 
+output "cloudtrail_log_group_name" {
+  description = "The name of the CloudTrail log group"
+  value       = aws_cloudwatch_log_group.cloudtrail.name
+}
+
 output "cloudtrail_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the CloudTrail role."
   value       = aws_iam_role.cloudtrail.arn


### PR DESCRIPTION
- Name is required for creating CloudWatch log metric filters