### PR TITLE
Fixes two dependency ordering bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The GRACE Logging subcomponent will also provide the resources required to creat
 | cloudtrail\_role\_id | The name of the CloudTrail role. |
 | logging\_bucket\_arn | The ARN of the logging bucket. |
 | logging\_bucket\_id | The name of the logging bucket. |
+| logging\_bucket\_policy | The policy text applied to the logging bucket |
 | secops\_policy\_id | The ID of the SecOps read only policy. |
 | secops\_role\_arn | The Amazon Resource Name \(ARN\) specifying the SecOps read only role. |
 | secops\_role\_id | The name of the SecOps read only role. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,6 +53,11 @@ output "logging_bucket_id" {
   value       = aws_s3_bucket.logging.id
 }
 
+output "logging_bucket_policy" {
+  description = "The policy text applied to the logging bucket"
+  value       = aws_s3_bucket_policy.logging.policy
+}
+
 output "access_bucket_id" {
   description = "The name of the access log bucket."
   value       = aws_s3_bucket.access.id

--- a/s3.tf
+++ b/s3.tf
@@ -67,6 +67,8 @@ data "template_file" "bucket_policy" {
 resource "aws_s3_bucket_policy" "logging" {
   bucket = aws_s3_bucket.logging.id
   policy = data.template_file.bucket_policy.rendered
+
+  depends_on = [aws_s3_bucket_public_access_block.logging]
 }
 
 ######################################


### PR DESCRIPTION
- adds `logging_bucket_policy` to outputs.tf and README.md (used to prevent S3 bucket usage before the policy is finished applying)
- adds dependency on logging bucket access block for logging bucket policy (prevents race between the two)