### PR TITLE
Does not add ":*" to ARN (Closes #42)

### DIFF
--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -13,7 +13,7 @@ resource "aws_cloudtrail" "cloudtrail" {
   is_multi_region_trail         = var.cloudtrail_multi_region
   enable_log_file_validation    = var.cloudtrail_enable_log_validation
   kms_key_id                    = aws_kms_key.cloudtrail.arn
-  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
+  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
 
   depends_on = [aws_s3_bucket_policy.logging]


### PR DESCRIPTION
The `":*"` needs to be added to the end of the `cloud_watch_logs_group_arn` with AWS provider v3.x.x. However, we are still using Terraform v0.12.x, which limits us to AWS provider v2.x.x, so adding the ":*" to the end of the ARN creates an invalid ARN.
- Closes #42 